### PR TITLE
feat: write data required for conductor to validate the block's hashes to the DA layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -88,10 +97,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cc"
@@ -215,6 +233,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek-ng"
+version = "4.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "rand_core",
+ "subtle-ng",
+ "zeroize",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,12 +291,43 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "crypto-common",
+]
+
+[[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-consensus"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
+dependencies = [
+ "curve25519-dalek-ng",
+ "hex",
+ "rand_core",
+ "sha2 0.9.9",
+ "zeroize",
 ]
 
 [[package]]
@@ -305,6 +367,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +390,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flex-error"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c606d892c9de11507fa0dcffc116434f94e105d0bbdc4e405b61519464c49d7b"
+dependencies = [
+ "eyre",
+ "paste",
+]
 
 [[package]]
 name = "fnv"
@@ -350,39 +432,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.26"
+name = "futures"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+
+[[package]]
+name = "futures-io"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
 
 [[package]]
 name = "futures-task"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
 
 [[package]]
 name = "futures-util"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
@@ -585,6 +689,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +870,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +914,12 @@ name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
@@ -867,6 +994,12 @@ dependencies = [
  "smallvec",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "percent-encoding"
@@ -1220,8 +1353,9 @@ dependencies = [
  "rs-cnc",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.6",
  "structopt",
+ "tendermint",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1234,6 +1368,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1259,6 +1402,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,13 +1426,26 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1298,6 +1465,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "slab"
@@ -1361,6 +1534,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "subtle-encoding"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "subtle-ng"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
+
+[[package]]
 name = "syn"
 version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1563,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1383,6 +1589,53 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "tendermint"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
+dependencies = [
+ "bytes",
+ "digest 0.10.6",
+ "ed25519",
+ "ed25519-consensus",
+ "flex-error",
+ "futures",
+ "num-traits",
+ "once_cell",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "serde_repr",
+ "sha2 0.10.6",
+ "signature",
+ "subtle",
+ "subtle-encoding",
+ "tendermint-proto",
+ "time",
+ "zeroize",
+]
+
+[[package]]
+name = "tendermint-proto"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
+dependencies = [
+ "bytes",
+ "flex-error",
+ "num-derive",
+ "num-traits",
+ "prost",
+ "prost-types",
+ "serde",
+ "serde_bytes",
+ "subtle-encoding",
+ "time",
 ]
 
 [[package]]
@@ -1431,6 +1684,32 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd80a657e71da814b8e5d60d3374fc6d35045062245d80224748ae522dd76f36"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1629,6 +1908,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "url"
@@ -1887,4 +2172,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,17 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
-name = "async-trait"
-version = "0.1.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1341,7 +1330,6 @@ name = "sequencer-relayer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64",
  "bech32",
  "clap 4.1.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-async-trait = "0.1"
 base64 = "0.21"
 bech32 = "0.9"
 hex = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 structopt = "0.3"
+tendermint = "0.30"
 tokio = { version = "1.24", features = [ "full" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2.15"

--- a/src/base64_string.rs
+++ b/src/base64_string.rs
@@ -1,0 +1,86 @@
+use base64::{engine::general_purpose, Engine as _};
+use serde::{
+    de::{self, Visitor},
+    Deserialize, Deserializer, Serialize,
+};
+use std::fmt;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct Base64String(pub Vec<u8>);
+
+impl Base64String {
+    pub fn from_string(s: String) -> Result<Base64String, base64::DecodeError> {
+        general_purpose::STANDARD.decode(s).map(Base64String)
+    }
+}
+
+impl std::fmt::Display for Base64String {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", general_purpose::STANDARD.encode(&self.0))
+    }
+}
+
+impl fmt::Debug for Base64String {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&general_purpose::STANDARD.encode(&self.0))
+    }
+}
+
+impl Serialize for Base64String {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&general_purpose::STANDARD.encode(&self.0))
+    }
+}
+
+impl<'de> Deserialize<'de> for Base64String {
+    fn deserialize<D>(deserializer: D) -> Result<Base64String, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_string(Base64StringVisitor)
+    }
+}
+
+struct Base64StringVisitor;
+
+impl Base64StringVisitor {
+    fn decode_string<E>(self, value: &str) -> Result<Base64String, E>
+    where
+        E: de::Error,
+    {
+        general_purpose::STANDARD
+            .decode(value)
+            .map(Base64String)
+            .map_err(|e| {
+                E::custom(format!(
+                    "failed to decode string {} from base64: {:?}",
+                    value, e
+                ))
+            })
+    }
+}
+
+impl<'de> Visitor<'de> for Base64StringVisitor {
+    type Value = Base64String;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a base64-encoded string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.decode_string(value)
+    }
+
+    fn visit_string<E>(self, value: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.decode_string(&value)
+    }
+}

--- a/src/bin/relayer.rs
+++ b/src/bin/relayer.rs
@@ -6,9 +6,7 @@ use tracing_subscriber::EnvFilter;
 use std::{str::FromStr, time};
 
 use sequencer_relayer::{
-    da::{CelestiaClient, DataAvailabilityClient},
-    sequencer::SequencerClient,
-    sequencer_block::SequencerBlock,
+    da::CelestiaClient, sequencer::SequencerClient, sequencer_block::SequencerBlock,
 };
 
 pub const DEFAULT_SEQUENCER_ENDPOINT: &str = "http://localhost:1317";

--- a/src/da.rs
+++ b/src/da.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use tracing::{debug, warn};
 
+use crate::base64_string::Base64String;
 use crate::sequencer_block::{Namespace, SequencerBlock, DEFAULT_NAMESPACE};
-use crate::types::Base64String;
 
 static DEFAULT_PFD_FEE: i64 = 2_000;
 static DEFAULT_PFD_GAS_LIMIT: u64 = 90_000;

--- a/src/da.rs
+++ b/src/da.rs
@@ -209,7 +209,6 @@ impl CelestiaClient {
                 }
             }
 
-            // TODO: where to validate that the indices are 0..n with no gaps?
             blocks.push(SequencerBlock {
                 block_hash: sequencer_namespace_data.block_hash.clone(),
                 header: sequencer_namespace_data.header.clone(),

--- a/src/da.rs
+++ b/src/da.rs
@@ -235,8 +235,8 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{CelestiaClient, DataAvailabilityClient, SequencerBlock, DEFAULT_NAMESPACE};
+    use crate::base64_string::Base64String;
     use crate::sequencer_block::get_namespace;
-    use crate::types::Base64String;
 
     #[tokio::test]
     async fn test_celestia_client() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod base64_string;
 pub mod da;
 pub mod sequencer;
 pub mod sequencer_block;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ pub mod base64_string;
 pub mod da;
 pub mod sequencer;
 pub mod sequencer_block;
+pub mod transaction;
 pub mod types;
 
 pub mod proto {

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -53,7 +53,7 @@ mod test {
     use bech32::{self, FromBase32, Variant};
 
     use super::SequencerClient;
-    use crate::types::Base64String;
+    use crate::base64_string::Base64String;
 
     #[test]
     fn test_decode_validator_address() {

--- a/src/sequencer_block.rs
+++ b/src/sequencer_block.rs
@@ -7,9 +7,10 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use tracing::{debug, info, warn};
 
+use crate::base64_string::Base64String;
 use crate::proto::SequencerMsg;
 use crate::proto::{TxBody, TxRaw};
-use crate::types::{Base64String, Block};
+use crate::types::Block;
 
 /// Cosmos SDK message type URL for SequencerMsgs.
 static SEQUENCER_TYPE_URL: &str = "/SequencerMsg";
@@ -135,7 +136,7 @@ fn cosmos_tx_body_to_sequencer_msgs(tx_body: TxBody) -> Result<Vec<SequencerMsg>
 #[cfg(test)]
 mod test {
     use super::{cosmos_tx_body_to_sequencer_msgs, parse_cosmos_tx, SEQUENCER_TYPE_URL};
-    use crate::types::Base64String;
+    use crate::base64_string::Base64String;
 
     #[test]
     fn test_parse_primary_tx() {

--- a/src/sequencer_block.rs
+++ b/src/sequencer_block.rs
@@ -66,6 +66,10 @@ impl SequencerBlock {
     /// from_cosmos_block converts a cosmos-sdk block into a SequencerBlock.
     /// it parses the block for SequencerMsgs and namespaces them accordingly.
     pub fn from_cosmos_block(b: Block) -> Result<Self, Error> {
+        if b.header.data_hash.is_none() {
+            return Err(anyhow!("block has no data hash"));
+        }
+
         // we unwrap generic txs into rollup-specific txs here,
         // and namespace them correspondingly
         let mut sequencer_txs = vec![];
@@ -97,7 +101,7 @@ impl SequencerBlock {
         }
 
         Ok(Self {
-            block_hash: b.header.data_hash, // TODO: is this the right hash?
+            block_hash: b.header.data_hash.unwrap(), // TODO: is this the right hash?
             sequencer_txs,
             rollup_txs,
         })

--- a/src/sequencer_block.rs
+++ b/src/sequencer_block.rs
@@ -10,7 +10,7 @@ use tracing::{debug, warn};
 use crate::base64_string::Base64String;
 use crate::proto::SequencerMsg;
 use crate::proto::{TxBody, TxRaw};
-use crate::types::Block;
+use crate::types::{Block, Header};
 
 /// Cosmos SDK message type URL for SequencerMsgs.
 static SEQUENCER_TYPE_URL: &str = "/SequencerMsg";
@@ -61,6 +61,7 @@ pub(crate) fn get_namespace(bytes: &[u8]) -> Namespace {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct SequencerBlock {
     pub block_hash: Base64String,
+    pub header: Header,
     pub sequencer_txs: Vec<IndexedTransaction>, // TODO: do we need this?
     /// namespace -> rollup txs
     pub rollup_txs: HashMap<Namespace, Vec<IndexedTransaction>>,
@@ -123,7 +124,8 @@ impl SequencerBlock {
         }
 
         Ok(Self {
-            block_hash: b.header.data_hash.unwrap(), // TODO: is this the right hash?
+            block_hash: Base64String(b.header.hash()?.as_bytes().to_vec()),
+            header: b.header,
             sequencer_txs,
             rollup_txs,
         })

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,0 +1,42 @@
+use prost;
+use tendermint::hash::Hash as TmHash;
+use tendermint::merkle;
+
+use crate::base64_string::Base64String;
+
+#[allow(dead_code)]
+fn tx_to_prost_bytes(tx: Vec<u8>) -> prost::alloc::vec::Vec<u8> {
+    let mut buf = prost::alloc::vec::Vec::new();
+    prost::encoding::bytes::encode(1, &tx, &mut buf);
+    buf
+}
+
+#[allow(dead_code)]
+fn txs_to_block_hash(txs: &[Base64String]) -> TmHash {
+    let txs = txs
+        .iter()
+        .map(|tx| tx_to_prost_bytes(tx.0.clone()))
+        .collect::<Vec<Vec<u8>>>();
+
+    TmHash::Sha256(merkle::simple_hash_from_byte_vectors::<
+        tendermint::crypto::default::Sha256,
+    >(&txs))
+}
+
+#[cfg(test)]
+mod test {
+    use super::txs_to_block_hash;
+    use crate::sequencer::SequencerClient;
+
+    #[tokio::test]
+    async fn test_txs_to_block_hash() {
+        let cosmos_endpoint = "http://localhost:1317".to_string();
+        let client = SequencerClient::new(cosmos_endpoint).unwrap();
+        let resp = client.get_latest_block().await.unwrap();
+        let data_hash = txs_to_block_hash(&resp.block.data.txs);
+        assert_eq!(
+            data_hash.as_bytes(),
+            &resp.block.header.data_hash.unwrap().0
+        );
+    }
+}

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -12,7 +12,7 @@ fn tx_to_prost_bytes(tx: Vec<u8>) -> prost::alloc::vec::Vec<u8> {
 }
 
 #[allow(dead_code)]
-fn txs_to_block_hash(txs: &[Base64String]) -> TmHash {
+pub(crate) fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
     let txs = txs
         .iter()
         .map(|tx| tx_to_prost_bytes(tx.0.clone()))
@@ -25,15 +25,15 @@ fn txs_to_block_hash(txs: &[Base64String]) -> TmHash {
 
 #[cfg(test)]
 mod test {
-    use super::txs_to_block_hash;
+    use super::txs_to_data_hash;
     use crate::sequencer::SequencerClient;
 
     #[tokio::test]
-    async fn test_txs_to_block_hash() {
+    async fn test_txs_to_data_hash() {
         let cosmos_endpoint = "http://localhost:1317".to_string();
         let client = SequencerClient::new(cosmos_endpoint).unwrap();
         let resp = client.get_latest_block().await.unwrap();
-        let data_hash = txs_to_block_hash(&resp.block.data.txs);
+        let data_hash = txs_to_data_hash(&resp.block.data.txs);
         assert_eq!(
             data_hash.as_bytes(),
             &resp.block.header.data_hash.unwrap().0

--- a/src/types.rs
+++ b/src/types.rs
@@ -163,8 +163,6 @@ mod test {
         let cosmos_endpoint = "http://localhost:1317".to_string();
         let client = SequencerClient::new(cosmos_endpoint).unwrap();
         let resp = client.get_latest_block().await.unwrap();
-        println!("LatestBlockResponse: {:?}", resp);
-
         let tm_header = header_to_tendermint_header(&resp.block.header).unwrap();
         let tm_header_hash = tm_header.hash();
         assert_eq!(tm_header_hash.as_bytes(), &resp.block_id.hash.0);

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,13 +26,13 @@ pub struct BlockResponse {
     pub block: Block,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq, Eq, Serialize)]
 pub struct BlockId {
     pub hash: Base64String,
     pub part_set_header: Parts,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq, Eq, Serialize)]
 pub struct Parts {
     pub total: u32,
     pub hash: Base64String,
@@ -62,7 +62,18 @@ pub struct CommitSig {
     pub signature: Base64String,
 }
 
+#[derive(Clone, Deserialize, Debug, Eq, PartialEq, Serialize)]
+pub struct Version {
+    pub block: String,
+    pub app: String,
+}
+
 #[derive(Deserialize, Debug)]
+pub struct Data {
+    pub txs: Vec<Base64String>,
+}
+
+#[derive(Clone, Deserialize, Debug, Eq, PartialEq, Serialize)]
 pub struct Header {
     pub version: Version,
     pub chain_id: String,
@@ -80,82 +91,102 @@ pub struct Header {
     pub proposer_address: Base64String,
 }
 
-#[derive(Deserialize, Debug)]
-pub struct Version {
-    pub block: String,
-    pub app: String,
+impl Default for Header {
+    /// default returns an empty header.
+    fn default() -> Self {
+        Header {
+            version: Version {
+                block: "0".to_string(),
+                app: "0".to_string(),
+            },
+            chain_id: "default".to_string(),
+            height: "0".to_string(),
+            time: "1970-01-01T00:00:00Z".to_string(),
+            last_block_id: None,
+            last_commit_hash: None,
+            data_hash: None,
+            validators_hash: Base64String(vec![]),
+            next_validators_hash: Base64String(vec![]),
+            consensus_hash: Base64String(vec![]),
+            app_hash: Base64String(vec![]),
+            last_results_hash: None,
+            evidence_hash: None,
+            proposer_address: Base64String(vec![]),
+        }
+    }
 }
 
-#[derive(Deserialize, Debug)]
-pub struct Data {
-    pub txs: Vec<Base64String>,
-}
+impl Header {
+    pub fn hash(&self) -> Result<TmHash, Error> {
+        let tm_header = self.to_tendermint_header()?;
+        Ok(tm_header.hash())
+    }
 
-/// header_to_tendermint_header converts a Tendermint RPC header to a tendermint-rs header.
-#[allow(dead_code)]
-fn header_to_tendermint_header(header: &Header) -> Result<TmHeader, Error> {
-    let last_block_id = header
-        .last_block_id
-        .as_ref()
-        .map(|id| {
-            Ok(TmBlockId {
-                hash: TmHash::try_from(id.hash.0.clone())?,
-                part_set_header: TmPartSetHeader::new(
-                    id.part_set_header.total,
-                    TmHash::try_from(id.part_set_header.hash.0.clone())?,
-                )?,
+    /// to_tendermint_header converts a Tendermint RPC header to a tendermint-rs header.
+    #[allow(dead_code)]
+    fn to_tendermint_header(&self) -> Result<TmHeader, Error> {
+        let last_block_id = self
+            .last_block_id
+            .as_ref()
+            .map(|id| {
+                Ok(TmBlockId {
+                    hash: TmHash::try_from(id.hash.0.clone())?,
+                    part_set_header: TmPartSetHeader::new(
+                        id.part_set_header.total,
+                        TmHash::try_from(id.part_set_header.hash.0.clone())?,
+                    )?,
+                })
             })
+            .map_or(Ok(None), |r: Result<TmBlockId, Error>| r.map(Some))?;
+
+        let last_commit_hash = self
+            .last_commit_hash
+            .as_ref()
+            .map(|h| TmHash::try_from(h.0.clone()))
+            .map_or(Ok(None), |r| r.map(Some))?;
+
+        let data_hash = self
+            .data_hash
+            .as_ref()
+            .map(|h| TmHash::try_from(h.0.clone()))
+            .map_or(Ok(None), |r| r.map(Some))?;
+
+        let last_results_hash = self
+            .last_results_hash
+            .as_ref()
+            .map(|h| TmHash::try_from(h.0.clone()))
+            .map_or(Ok(None), |r| r.map(Some))?;
+
+        let evidence_hash = self
+            .evidence_hash
+            .as_ref()
+            .map(|h| TmHash::try_from(h.0.clone()))
+            .map_or(Ok(None), |r| r.map(Some))?;
+
+        Ok(TmHeader {
+            version: TmVersion {
+                block: self.version.block.parse::<u64>()?,
+                app: self.version.app.parse::<u64>()?,
+            },
+            chain_id: TmChainId::try_from(self.chain_id.clone())?,
+            height: TmHeight::try_from(self.height.parse::<u64>()?)?,
+            time: Time::parse_from_rfc3339(&self.time)?,
+            last_block_id,
+            last_commit_hash,
+            data_hash,
+            validators_hash: TmHash::try_from(self.validators_hash.0.clone())?,
+            next_validators_hash: TmHash::try_from(self.next_validators_hash.0.clone())?,
+            consensus_hash: TmHash::try_from(self.consensus_hash.0.clone())?,
+            app_hash: AppHash::try_from(self.app_hash.0.clone())?,
+            last_results_hash,
+            evidence_hash,
+            proposer_address: AccountId::try_from(self.proposer_address.0.clone())?,
         })
-        .map_or(Ok(None), |r: Result<TmBlockId, Error>| r.map(Some))?;
-
-    let last_commit_hash = header
-        .last_commit_hash
-        .as_ref()
-        .map(|h| TmHash::try_from(h.0.clone()))
-        .map_or(Ok(None), |r| r.map(Some))?;
-
-    let data_hash = header
-        .data_hash
-        .as_ref()
-        .map(|h| TmHash::try_from(h.0.clone()))
-        .map_or(Ok(None), |r| r.map(Some))?;
-
-    let last_results_hash = header
-        .last_results_hash
-        .as_ref()
-        .map(|h| TmHash::try_from(h.0.clone()))
-        .map_or(Ok(None), |r| r.map(Some))?;
-
-    let evidence_hash = header
-        .evidence_hash
-        .as_ref()
-        .map(|h| TmHash::try_from(h.0.clone()))
-        .map_or(Ok(None), |r| r.map(Some))?;
-
-    Ok(TmHeader {
-        version: TmVersion {
-            block: header.version.block.parse::<u64>()?,
-            app: header.version.app.parse::<u64>()?,
-        },
-        chain_id: TmChainId::try_from(header.chain_id.clone())?,
-        height: TmHeight::try_from(header.height.parse::<u64>()?)?,
-        time: Time::parse_from_rfc3339(&header.time)?,
-        last_block_id,
-        last_commit_hash,
-        data_hash,
-        validators_hash: TmHash::try_from(header.validators_hash.0.clone())?,
-        next_validators_hash: TmHash::try_from(header.next_validators_hash.0.clone())?,
-        consensus_hash: TmHash::try_from(header.consensus_hash.0.clone())?,
-        app_hash: AppHash::try_from(header.app_hash.0.clone())?,
-        last_results_hash,
-        evidence_hash,
-        proposer_address: AccountId::try_from(header.proposer_address.0.clone())?,
-    })
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use super::header_to_tendermint_header;
     use crate::sequencer::SequencerClient;
 
     #[tokio::test]
@@ -163,7 +194,7 @@ mod test {
         let cosmos_endpoint = "http://localhost:1317".to_string();
         let client = SequencerClient::new(cosmos_endpoint).unwrap();
         let resp = client.get_latest_block().await.unwrap();
-        let tm_header = header_to_tendermint_header(&resp.block.header).unwrap();
+        let tm_header = &resp.block.header.to_tendermint_header().unwrap();
         let tm_header_hash = tm_header.hash();
         assert_eq!(tm_header_hash.as_bytes(), &resp.block_id.hash.0);
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,7 +123,6 @@ impl Header {
     }
 
     /// to_tendermint_header converts a Tendermint RPC header to a tendermint-rs header.
-    #[allow(dead_code)]
     fn to_tendermint_header(&self) -> Result<TmHeader, Error> {
         let last_block_id = self
             .last_block_id


### PR DESCRIPTION
- done: reconstruct `block_id.hash` from header
- done: reconstruct `data_hash` from transactions
- done: write the entire cosmos tx to celestia; add tx indices for `data_hash` reconstruction
- done: write header to celestia

closes #8