### PR TITLE
rewrite docker test scripts to use exec

### DIFF
--- a/docker/start-bridge.sh
+++ b/docker/start-bridge.sh
@@ -12,7 +12,7 @@ echo  # newline
 
 export CELESTIA_CUSTOM=test:`cat genesis.hash`
 echo $CELESTIA_CUSTOM
-./celestia bridge start \
+exec ./celestia bridge start \
   --node.store /bridge --gateway \
   --core.ip 192.167.10.10 \
   --keyring.accname validator

--- a/docker/start-celestia-appd.sh
+++ b/docker/start-celestia-appd.sh
@@ -28,4 +28,4 @@ sed -i'.bak' 's/index_all_keys = false/index_all_keys = true/g' ~/.celestia-app/
 sed -i'.bak' 's/mode = "full"/mode = "validator"/g' ~/.celestia-app/config/config.toml
 
 # Start the celestia-app
-celestia-appd start
+exec celestia-appd start

--- a/docker/test-docker-compose.yml
+++ b/docker/test-docker-compose.yml
@@ -4,12 +4,7 @@ services:
   core0:
     container_name: core0
     image: "ghcr.io/celestiaorg/celestia-app:v0.11.0"
-    entrypoint: [
-      "/bin/bash"
-    ]
-    command: [
-      "/start-celestia-appd.sh"
-    ]
+    entrypoint: "./start-celestia-appd.sh"
     volumes:
       - ${PWD}/docker/start-celestia-appd.sh:/start-celestia-appd.sh:ro
       - keyring-volume:/root/.celestia-app/keyring-test
@@ -22,12 +17,7 @@ services:
     depends_on:
       - core0
     image: "ghcr.io/celestiaorg/celestia-node:0.6.1"
-    entrypoint: [
-      "/bin/bash"
-    ]
-    command: [
-      "/start-bridge.sh"
-    ]
+    entrypoint: "./start-bridge.sh"
     volumes:
       - ${PWD}/docker/wait-for-it.sh:/wait-for-it.sh:ro
       - ${PWD}/docker/start-bridge.sh:/start-bridge.sh:ro


### PR DESCRIPTION
My syntax highlighter did not like `test-docker-compose.yml`. Looking closer as it I noticed that the scripts we are starting are being run in a subshell rather than as PID1.

This PR cleans up the docker compose file, and also uses `exec` to run the various celestia commands.

Nice bonus: since signals are directly passed to celestia, the containers are taken down much faster instead of being sigkilled after some timeout.