### PR TITLE
run tests in isolated environments

### DIFF
--- a/.github/workflows/install_podman.sh
+++ b/.github/workflows/install_podman.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+ubuntu_version=22.04
+key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$ubuntu_version/Release.key"
+sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_$ubuntu_version"
+echo "deb $sources_url/ /" | tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+curl -fsSL $key_url | gpg --dearmor | tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+apt update
+apt install -y podman

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,6 @@ jobs:
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Clone Metro
-        uses: actions/checkout@v2
-        with:
-          repository: histolabs/metro
-          path: './metro'
-      - name: Build Metro
-        run: |
-          cd metro && make install
-          bash scripts/single-node.sh &
       - uses: actions/checkout@v2
       - name: Install stable
         run: rustup toolchain install stable
@@ -38,8 +29,31 @@ jobs:
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
-      - name: Start Celestia core app and bridge node
-        run: docker-compose -f docker/test-docker-compose.yml up -d bridge0
+      - name: install podman 4
+        run: sudo bash $GITHUB_WORKSPACE/.github/workflows/install_podman.sh
+      - name: start podman
+        run: |
+          systemctl restart --user podman
+          systemctl restart --user podman.socket
+      - name: populate sequencer stack template
+        uses: cuchi/jinja2-action@v1.2.0
+        with:
+          template: templates/sequencer_relayer_stack.yaml.jinja2
+          output_file: sequencer_relayer_stack_init.yaml
+          strict: true
+          variables: |
+            pod_name=sequencer_relayer_stack_pull
+            celestia_home_volume=celestia-home-vol
+            metro_home_volume=metro-home-vol
+            bridge_host_port=26659
+            sequencer_host_port=1318
+            scripts_host_volume=containers
+      - name: start stack to to download all images
+        run: |
+          podman kube play --start=false --replace \
+            sequencer_relayer_stack_init.yaml
+      - name: remove stack pod
+        run: podman pod rm --all
       - name: Install protoc
         run: sudo apt-get install protobuf-compiler
       - name: Build
@@ -51,9 +65,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -- --nocapture --color always --test-threads=1
-      - name: Clean up Docker containers used for testing
-        run: ./docker/cleanup-docker.sh
+          args: -- --nocapture --color always
 
   fmt:
     name: fmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,10 +27,94 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.69"
+name = "anstream"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
+checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+
+[[package]]
+name = "askama"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47cbc3cf73fa8d9833727bbee4835ba5c421a0d65b72daf9a7b5d0e0f9cfb57e"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22fbe0413545c098358e56966ff22cdd039e10215ae213cfbd65032b119fc94"
+dependencies = [
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "nom",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "autocfg"
@@ -34,9 +124,24 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0de75129aa8d0cceaf750b89013f0e08804d6ec61416da787b35ad0d7cddf1"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bech32"
@@ -82,6 +187,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+
+[[package]]
+name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
@@ -103,52 +214,61 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
+ "serde",
+ "time 0.1.45",
+ "wasm-bindgen",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "4.1.9"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9d6ada83c1edcce028902ea27dd929069c70df4c7600b131b4d9a1ad2879cc"
+checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
 dependencies = [
- "bitflags",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "is-terminal",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "bitflags",
+ "clap_lex",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.1.9"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -161,18 +281,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.3"
+name = "colorchoice"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
+name = "containers-api"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef94b0ff8338282b35bafb408eb0a3e53ba05bdb3b36840589ab9a67a6682593"
+dependencies = [
+ "chrono",
+ "flate2",
+ "futures-util",
+ "http",
+ "hyper",
+ "hyperlocal",
+ "log",
+ "mime",
+ "paste",
+ "pin-project 1.0.12",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+checksum = "280a9f2d8b3a38871a3c8a46fb80db65e5e5ed97da80c4d08bf27fb63e35e181"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -213,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d3488e7665a7a483b57e25bdd90d0aeb2bc7608c8d0346acf2ad3f1caf1d62"
+checksum = "f61f1b6389c3fe1c316bf8a4dccc90a38208354b330925bce1f74a6c4756eb93"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -225,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fcaf066a053a41a81dfb14d57d99738b767febb8b735c3016e469fac5da690"
+checksum = "12cee708e8962df2aeb38f594aae5d827c022b6460ac71a7a3e2c3c2aae5a07b"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -235,24 +394,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ef98b8b717a829ca5603af80e1f9e2e48013ab227b68ef37872ef84ee479bf"
+checksum = "7944172ae7e4068c533afbb984114a56c46e9ccddda550499caa222902c7f7bb"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "086c685979a698443656e5cf7856c95c642295a38599f12fb1ff76fb28d19892"
+checksum = "2345488264226bf682893e25de0769f3360aac9957980ec49361b083ddaa5bc5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -347,13 +506,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -386,10 +545,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flex-error"
@@ -418,12 +599,13 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531ac96c6ff5fd7c62263c5e3c67a603af4fcaee2e1a0ae5565ba3a11e69e549"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -432,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -442,46 +624,85 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "futures_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
+dependencies = [
+ "bytes 0.5.6",
+ "futures",
+ "memchr",
+ "pin-project 0.4.30",
 ]
 
 [[package]]
 name = "generic-array"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -500,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -511,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -562,12 +783,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "fnv",
  "itoa",
 ]
@@ -578,7 +808,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "http",
  "pin-project-lite",
 ]
@@ -596,12 +826,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "hyper"
-version = "0.14.24"
+name = "humansize"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
- "bytes",
+ "libm",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
+dependencies = [
+ "bytes 1.4.0",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -633,17 +872,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.53"
+name = "hyperlocal"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project 1.0.12",
+ "tokio",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0722cd7114b7de04316e7ea5456a0bbb20e4adb46fd27a3697adb812cff0f37c"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -674,9 +926,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -693,31 +945,31 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e86b86ae312accbf05ade23ce76b625e0e47a255712b7414037385a1c05380"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "12b6ee2129af8d4fb011108c73d99a1b83a85977f23b82460c0ae2e25bb4b57f"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
+checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -731,9 +983,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "js-sys"
@@ -752,9 +1004,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "link-cplusplus"
@@ -767,9 +1025,19 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
+
+[[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -797,9 +1065,34 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4192263c238a5f0d0c6bfd21f336a313a4ce1c450542449ca191bb657b4642ef"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -820,6 +1113,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,7 +1130,7 @@ checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -872,10 +1175,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.4.1"
+name = "parking_lot"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "paste"
@@ -900,6 +1220,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef0f924a5ee7ea9cbcea77529dba45f8a9ba9f622419fe3386ca581a3ae9d5a"
+dependencies = [
+ "pin-project-internal 0.4.30",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal 1.0.12",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851c8d0ce9bebe43790dedfc86614c23494ac9f423dd618d3a61fc693eafe61e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,6 +1272,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "podman-api"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d0ade207138f12695cb4be3b590283f1cf764c5c4909f39966c4b4b0dba7c1e"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "bytes 1.4.0",
+ "chrono",
+ "containers-api",
+ "flate2",
+ "futures-util",
+ "futures_codec",
+ "log",
+ "paste",
+ "podman-api-stubs",
+ "serde",
+ "serde_json",
+ "tar",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "podman-api-stubs"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d280c623f633a0dded88feab9e387f98451506431d5b7308a858c643305dcee"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,64 +1315,40 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "prost-derive",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "heck",
  "itertools",
  "lazy_static",
@@ -987,38 +1359,38 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1082,7 +1454,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.8",
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -1104,21 +1476,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.8",
- "redox_syscall",
+ "getrandom 0.2.9",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.1"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "regex-syntax",
 ]
@@ -1134,27 +1515,18 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
- "base64",
- "bytes",
+ "base64 0.21.0",
+ "bytes 1.4.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -1204,10 +1576,10 @@ dependencies = [
 [[package]]
 name = "rs-cnc"
 version = "0.1.0"
-source = "git+https://github.com/astriaorg/rs-cnc.git?branch=superfluffy/rustls-feature#4ccacb58cfe9f2083e1bd2dd878d8e3b9ed4a724"
+source = "git+https://github.com/astriaorg/rs-cnc.git#2ebf140778db12835eba686f6c5111eb429218e1"
 dependencies = [
- "base64",
- "bytes",
+ "base64 0.21.0",
+ "bytes 1.4.0",
  "eyre",
  "hex",
  "rand 0.8.5",
@@ -1218,16 +1590,16 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.9"
+version = "0.37.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
+checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1248,20 +1620,26 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.0",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "scratch"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "1792db035ce95be60c3f8853017b3999209281c24e2ba5bc8e59bf97a0c590c1"
 
 [[package]]
 name = "sct"
@@ -1277,13 +1655,17 @@ dependencies = [
 name = "sequencer-relayer"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "askama",
+ "base64 0.21.0",
  "bech32",
  "clap",
  "dirs",
  "ed25519-dalek",
  "eyre",
  "hex",
+ "home",
+ "once_cell",
+ "podman-api",
  "prost",
  "prost-build",
  "prost-types",
@@ -1297,13 +1679,15 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "users",
+ "uuid",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
@@ -1319,20 +1703,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -1341,13 +1725,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
+checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1418,9 +1802,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -1461,9 +1845,9 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "syn"
-version = "1.0.108"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56e159d99e6c2b93995d171050271edb50ecc5288fbc7cc17de8fdce4e58c14"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1471,29 +1855,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.12.6"
+name = "syn"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "unicode-xid",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1502,7 +1895,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b90c3c1e32352551f0f1639ce765e4c66ce250c733d4b9ba1aff81130437465c"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "digest 0.10.6",
  "ed25519",
  "ed25519-consensus",
@@ -1521,7 +1914,7 @@ dependencies = [
  "subtle",
  "subtle-encoding",
  "tendermint-proto",
- "time",
+ "time 0.3.20",
  "zeroize",
 ]
 
@@ -1531,7 +1924,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e553ed65874c3f35a71eb60d255edfea956274b5af37a0297d54bba039fe45e3"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "flex-error",
  "num-derive",
  "num-traits",
@@ -1540,7 +1933,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle-encoding",
- "time",
+ "time 0.3.20",
 ]
 
 [[package]]
@@ -1554,22 +1947,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1580,6 +1973,17 @@ checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
 ]
 
 [[package]]
@@ -1625,31 +2029,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
 dependencies = [
  "autocfg",
- "bytes",
+ "bytes 1.4.0",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1669,7 +2073,7 @@ version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
 dependencies = [
- "bytes",
+ "bytes 1.4.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
@@ -1703,7 +2107,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1772,16 +2176,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.10"
+name = "unicase"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -1799,12 +2212,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1819,6 +2226,31 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+dependencies = [
+ "getrandom 0.2.9",
 ]
 
 [[package]]
@@ -1851,6 +2283,12 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+
+[[package]]
+name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
@@ -1876,7 +2314,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-shared",
 ]
 
@@ -1910,7 +2348,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1993,18 +2431,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -2013,65 +2445,131 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.1"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"
@@ -2080,6 +2578,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2093,12 +2600,11 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.3"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
- "synstructure",
+ "syn 2.0.15",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,15 @@ features = ["rustls"]
 
 [build-dependencies]
 prost-build = "0.11"
+
+[dev-dependencies]
+podman-api = "0.10.0"
+uuid = { version = "1.3.1", features = ["v4"] }
+tokio = { version = "1.24", features = [ "parking_lot", "sync", "time" ] }
+askama = "0.12.0"
+once_cell = "1.17.1"
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+users = "0.11.0"
+[target.'cfg(target_os = "macos")'.dev-dependencies]
+home = "0.5.4"

--- a/README.md
+++ b/README.md
@@ -10,66 +10,123 @@ Components:
 ## Requirements
 
 - Rust 1.66
-- Go 1.19 (for running [metro](https://github.com/astriaorg/metro.git))
+- Podman 4 (for running tests)
 
 ## Build
 
-```bash
-cargo build --release
+```sh
+$ cargo build --bin relayer --release
 ```
 
 ## Test
 
-Run [metro](https://github.com/astriaorg/metro.git):
-```bash
-git clone https://github.com/astriaorg/metro.git
-cd metro
-git checkout noot/msg-type
-make install
-bash scripts/single-node.sh
+To run integration tests a (rootless) podman API service must be present.
+Currently, only macOS and Linux are supported. Installation instructions
+are available on [podman.io](https://podman.io/getting-started/installation.html).
+
+After following the steps for MacOS, the podman API service should be immediately
+available. On linux, one might need to issue:
+```sh
+$ systemctl --user enable --now podman.socket
+```
+Because podman starts a pod of several containers, it is advisable to make a
+dry-run for podman to pull all images first:
+```sh
+$ podman run \
+  -e pod_name=sequencer_relayer_stack \
+  -e celestia_home_volume=celestia-home-vol \
+  -e metro_home_volume=metro-home-vol \
+  -e bridge_host_port=26659 \
+  -e sequencer_host_port=1318 \
+  -e scripts_host_volume=$PWD/containers \
+  -v $PWD/templates:/data/templates \
+  bbcrd/j2cli:latest \
+  -o templates/sequencer_relayer_stack.yaml \
+  templates/sequencer_relayer_stack.yaml.jinja2
+
+$ podman kube play --start=false templates/sequencer_relayer_stack.yaml
+```
+Tests can then be run with
+```sh
+$ cargo test
+```
+Note: because most tests require that blocks be available on the data
+availability layer (celestia) or in the sequencer (metro), integration tests
+currently have very long `sleep` steps, waiting for 30 seconds and more to
+ensure that blocks have been commited prior to executing API calls. To
+run onl library unit tests and skip integration tests run:
+```sh
+$ cargo test --lib
 ```
 
-Run a Celestia cluster:
-```bash
-git clone https://github.com/astriaorg/sequencer-relayer.git
-cd sequencer-relayer
-docker compose -f docker/test-docker-compose.yml up -d bridge0
-```
+### Troubleshooting
 
-Then, you can run the unit tests:
-```bash
-cargo test -- --test-threads=1
+Sometimes pods don't get stopped and cleaned up after tests have finished running.
+This is frequently related to ports in the range 1024 to 65536 not being available.
+You will then see errors like these:
+```
+failed playing YAML failed on podman:
+Fault {
+  code: 500,
+  message: "playing YAML file: starting some containers: internal libpod error"
+}  
+```
+Try stopping all pods and rerunning the command:
+```sh
+$ podman pod stop --all && podman pod rm --all
+$ cargo test
 ```
 
 ## Run
 
+With Metro and Celestia running locally (see below), start the relayer with
 While running Metro and Celestia, start the relayer:
-```bash
-./target/release/relayer
+```sh
+$ cargo run --bin relayer --release
+# Or after having built it
+$ ./target/release/relayer
+```
+
+The celestia cluster can be started by using the provided docker compose:
+```sh
+$ docker compose -f docker/test-docker-compose.yml up -d bridge0
+```
+
+Metro is compiled from source:
+```sh
+$ git clone https://github.com/astriaorg/metro.git
+$ cd metro
+$ git checkout noot/msg-type
+$ make install
+$ bash scripts/single-node.sh
 ```
 
 Note: the relayer automatically uses the validator private key located at `~/.metro/config/priv_validator_key.json`. You can specify the file with `-v`.
 
 Then, submit a tx to Metro:
-```bash
-metro tx bank send validator metro1sdfn0kunm8yzm3rpxeqdcc0fk0ygw2lgggtnhp 300utick --keyring-backend="test" --fees 210utick --yes
+```sh
+$ metro tx bank send validator \
+  metro1sdfn0kunm8yzm3rpxeqdcc0fk0ygw2lgggtnhp 300utick \
+  --keyring-backend="test" \
+  --fees 210utick \
+  --yes
 ```
 
 You should see some logs such as:
-```bash
+```sh
 Mar 03 14:17:21.432  INFO relayer: got block with height 82 from sequencer
 Mar 03 14:17:22.561  INFO relayer: submitted block 82 to DA layer: tx count=1
 ```
 
 Alternatively, you can use the small testing program [here](https://github.com/astriaorg/metro-transactions) to submit both "primary" and "secondary" transactions to Metro:
-```bash
-git clone https://github.com/astriaorg/metro-transactions
-cd metro-transactions
-go run main.go
+```sh
+$ git clone https://github.com/astriaorg/metro-transactions
+$ cd metro-transactions
+$ go run main.go
 ```
 
 ## Running with Docker
-```bash
+```sh
 # must map priv_validator_key.json to the container
-docker run --rm -v ~/.metro/config/priv_validator_key.json:/root/.metro/config/priv_validator_key.json ghcr.io/astriaorg/sequencer-relayer:latest 
+$ docker run --rm -v ~/.metro/config/priv_validator_key.json:/root/.metro/config/priv_validator_key.json ghcr.io/astriaorg/sequencer-relayer:latest 
 ```

--- a/containers/configure-metro-podman.sh
+++ b/containers/configure-metro-podman.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -o errexit -o nounset -o pipefail
+
+# change ports that we know metro metro will not receive messages on
+# so they won't interfere with celestia-app ports:
+#
+# ~/.metro # netstat -lntp
+# Active Internet connections (only servers)
+# Proto Recv-Q Send-Q Local Address           Foreign Address         State       PID/Program name
+#                     config.toml:.rpc.pprof_laddr
+# tcp        0      0 127.0.0.1:6060          0.0.0.0:*               LISTEN      110/metro
+#											config.toml:.rpc.laddr
+# tcp        0      0 :::26657                :::*                    LISTEN      110/metro
+#											p2p.laddr
+# tcp        0      0 :::26656                :::*                    LISTEN      110/metro
+#                     app.toml:.api.address
+# tcp        0      0 :::1317                 :::*                    LISTEN      110/metro
+#                     app.toml:.grpc.address
+# tcp        0      0 :::9091                 :::*                    LISTEN      110/metro
+#                     app.toml:.grpc-web.address
+# tcp        0      0 :::9090                 :::*                    LISTEN      110/metro
+dasel put -r toml '.rpc.pprof_laddr' -t string -v "127.0.0.1:60000" -f "$home_dir/config/config.toml"
+dasel put -r toml '.rpc.laddr' -t string -v "tcp://0.0.0.0:60001" -f "$home_dir/config/config.toml"
+dasel put -r toml '.p2p.laddr' -t string -v "tcp://0.0.0.0:60002" -f "$home_dir/config/config.toml"
+dasel put -r toml '.api.address' -t string -v "tcp://0.0.0.0:1318" -f "$home_dir/config/app.toml"
+dasel put -r toml '.grpc.address' -t string -v "0.0.0.0:9100" -f "$home_dir/config/app.toml"
+dasel put -r toml '.grpc-web.address' -t string -v "0.0.0.0:9101" -f "$home_dir/config/app.toml"

--- a/containers/init-bridge-podman.sh
+++ b/containers/init-bridge-podman.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+./celestia bridge init \
+  --node.store "$home_dir/bridge" \
+  --core.ip 127.0.0.1
+cp -r "$home_dir/keyring-test" "$home_dir/bridge/keys/"

--- a/containers/init-celestia-appd-podman.sh
+++ b/containers/init-celestia-appd-podman.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+celestia-appd init "$chainid" \
+  --chain-id "$chainid" \
+  --home "$home_dir"
+
+celestia-appd keys add \
+  "$validator_key_name" \
+  --keyring-backend="$keyring_backend" \
+  --home "$home_dir"
+
+validator_key=`celestia-appd keys show "$validator_key_name" -a --keyring-backend="$keyring_backend" --home "$home_dir"`
+celestia-appd add-genesis-account \
+  "$validator_key" \
+  --home "$home_dir" \
+  "$coins"
+
+celestia-appd gentx \
+  "$validator_key_name" \
+  "$validator_stake" \
+  --keyring-backend="$keyring_backend" \
+  --chain-id "$chainid" \
+  --home "$home_dir" \
+  --orchestrator-address "$validator_key" \
+  --evm-address "$evm_address"
+
+celestia-appd collect-gentxs --home "$home_dir"

--- a/containers/init-metro-podman.sh
+++ b/containers/init-metro-podman.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+metro init "$chainid" \
+  --chain-id "$chainid" \
+  --home "$home_dir"
+
+metro keys add "$validator_key_name" \
+  --keyring-backend="$keyring_backend" \
+  --home "$home_dir"
+
+validator_key=`metro keys show "$validator_key_name" -a --keyring-backend="$keyring_backend" --home "$home_dir"`
+metro add-genesis-account "$validator_key" "$coins" \
+  --home "$home_dir"
+
+metro gentx "$validator_key_name" "$validator_stake" \
+  --keyring-backend="$keyring_backend" \
+  --chain-id "$chainid" \
+  --orchestrator-address "$validator_key" \
+  --evm-address "$evm_address" \
+  --home "$home_dir"
+
+metro collect-gentxs \
+  --home "$home_dir"

--- a/containers/start-bridge-podman.sh
+++ b/containers/start-bridge-podman.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -o errexit -o nounset -o pipefail
+
+genesis_hash=$(curl -s -S -X GET "http://127.0.0.1:26657/block?height=1" | jq -r '.result.block_id.hash')
+if [ -z "$genesis_hash" ] 
+then
+  echo "did not receive genesis hash from celestia; exiting"
+  exit 1
+else
+  echo "genesis hash received: $genesis_hash"
+fi
+
+export CELESTIA_CUSTOM="test:$genesis_hash"
+  # --p2p.network "test:$celestia_custom"
+export GOLOG_LOG_LEVEL="debug"
+exec ./celestia bridge start \
+  --node.store "$home_dir/bridge" \
+  --gateway \
+  --keyring.accname "$validator_key_name"

--- a/containers/start-celestia-appd-podman.sh
+++ b/containers/start-celestia-appd-podman.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+# Start the celestia-app
+exec celestia-appd start --home "${home_dir}"

--- a/containers/start-metro-podman.sh
+++ b/containers/start-metro-podman.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -o errexit -o nounset
+
+# Start the celestia-app
+exec metro start --home "${home_dir}"

--- a/docker/Dockerfile.celestia-node
+++ b/docker/Dockerfile.celestia-node
@@ -1,0 +1,5 @@
+FROM ghcr.io/celestiaorg/celestia-node:0.6.1
+
+RUN apt-get update && apt-get -y install jq curl
+
+ENTRYPOINT ["/bin/bash"]

--- a/src/da.rs
+++ b/src/da.rs
@@ -128,8 +128,10 @@ impl CelestiaClient {
     /// the keypair is used to sign the data that is submitted to Celestia,
     /// specifically within submit_block.
     pub fn new(endpoint: String) -> eyre::Result<Self> {
-        let cnc =
-            CelestiaNodeClient::new(endpoint).wrap_err("failed creating celestia node client")?;
+        let cnc = CelestiaNodeClient::builder()
+            .base_url(endpoint)
+            .build()
+            .wrap_err("failed creating celestia node client")?;
         Ok(CelestiaClient { client: cnc })
     }
 
@@ -400,113 +402,5 @@ impl CelestiaClient {
         }
 
         Ok(Some(rollup_data_for_block.data.rollup_txs))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use ed25519_dalek::{Keypair, PublicKey};
-    use rand::rngs::OsRng;
-    use std::collections::HashMap;
-
-    use super::{CelestiaClient, SequencerBlock, DEFAULT_NAMESPACE};
-    use crate::base64_string::Base64String;
-    use crate::sequencer_block::{get_namespace, IndexedTransaction};
-
-    #[tokio::test]
-    async fn test_get_latest_height() {
-        // TODO: put these defaults somewhere, use them in bin/relayer
-        let base_url = "http://localhost:26659".to_string();
-        let client = CelestiaClient::new(base_url).unwrap();
-        let height = client.get_latest_height().await.unwrap();
-        assert!(height > 0);
-    }
-
-    #[tokio::test]
-    async fn test_get_blocks_public_key_filter() {
-        // test that get_blocks only gets blocked signed with a specific key
-        let keypair = Keypair::generate(&mut OsRng);
-        let base_url = "http://localhost:26659".to_string();
-        let client = CelestiaClient::new(base_url).unwrap();
-        let tx = Base64String(b"noot_was_here".to_vec());
-
-        let block_hash = Base64String(vec![99; 32]);
-        let block = SequencerBlock {
-            block_hash: block_hash.clone(),
-            header: Default::default(),
-            sequencer_txs: vec![IndexedTransaction {
-                index: 0,
-                transaction: tx.clone(),
-            }],
-            rollup_txs: HashMap::new(),
-        };
-
-        let submit_block_resp = client.submit_block(block, &keypair).await.unwrap();
-        let height = submit_block_resp
-            .namespace_to_block_num
-            .get(&DEFAULT_NAMESPACE.to_string())
-            .unwrap();
-
-        // generate new, different key
-        let keypair = Keypair::generate(&mut OsRng);
-        let public_key = PublicKey::from_bytes(&keypair.public.to_bytes()).unwrap();
-        let resp = client.get_blocks(*height, Some(&public_key)).await.unwrap();
-        assert!(resp.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_celestia_client() {
-        // test submit_block
-        let keypair = Keypair::generate(&mut OsRng);
-        let public_key = PublicKey::from_bytes(&keypair.public.to_bytes()).unwrap();
-
-        let base_url = "http://localhost:26659".to_string();
-        let client = CelestiaClient::new(base_url).unwrap();
-        let tx = Base64String(b"noot_was_here".to_vec());
-        let secondary_namespace = get_namespace(b"test_namespace");
-        let secondary_tx = Base64String(b"noot_was_here_too".to_vec());
-
-        let block_hash = Base64String(vec![99; 32]);
-        let mut block = SequencerBlock {
-            block_hash: block_hash.clone(),
-            header: Default::default(),
-            sequencer_txs: vec![IndexedTransaction {
-                index: 0,
-                transaction: tx.clone(),
-            }],
-            rollup_txs: HashMap::new(),
-        };
-        block.rollup_txs.insert(
-            secondary_namespace.clone(),
-            vec![IndexedTransaction {
-                index: 1,
-                transaction: secondary_tx.clone(),
-            }],
-        );
-
-        let submit_block_resp = client.submit_block(block, &keypair).await.unwrap();
-        let height = submit_block_resp
-            .namespace_to_block_num
-            .get(&DEFAULT_NAMESPACE.to_string())
-            .unwrap();
-
-        // test check_block_availability
-        let resp = client.check_block_availability(*height).await.unwrap();
-        assert_eq!(resp.height, *height);
-
-        // test get_blocks
-        let resp = client.get_blocks(*height, Some(&public_key)).await.unwrap();
-        assert_eq!(resp.len(), 1);
-        assert_eq!(resp[0].block_hash, block_hash);
-        assert_eq!(resp[0].header, Default::default());
-        assert_eq!(resp[0].sequencer_txs.len(), 1);
-        assert_eq!(resp[0].sequencer_txs[0].index, 0);
-        assert_eq!(resp[0].sequencer_txs[0].transaction, tx);
-        assert_eq!(resp[0].rollup_txs.len(), 1);
-        assert_eq!(resp[0].rollup_txs[&secondary_namespace][0].index, 1);
-        assert_eq!(
-            resp[0].rollup_txs[&secondary_namespace][0].transaction,
-            secondary_tx
-        );
     }
 }

--- a/src/sequencer.rs
+++ b/src/sequencer.rs
@@ -53,10 +53,8 @@ impl SequencerClient {
 
 #[cfg(test)]
 mod test {
-    use bech32::{self, FromBase32, Variant};
-
-    use super::SequencerClient;
     use crate::base64_string::Base64String;
+    use bech32::{self, FromBase32, Variant};
 
     #[test]
     fn test_decode_validator_address() {
@@ -73,22 +71,5 @@ mod test {
             validator_address_from_block.0
         );
         assert_eq!(variant, Variant::Bech32);
-    }
-
-    #[tokio::test]
-    async fn test_get_latest_block() {
-        let cosmos_endpoint = "http://localhost:1317".to_string();
-        let client = SequencerClient::new(cosmos_endpoint).unwrap();
-        let resp = client.get_latest_block().await.unwrap();
-        println!("LatestBlockResponse: {:?}", resp);
-    }
-
-    #[tokio::test]
-    async fn test_get_block() {
-        let cosmos_endpoint = "http://localhost:1317".to_string();
-        let client = SequencerClient::new(cosmos_endpoint).unwrap();
-        let resp = client.get_latest_block().await.unwrap();
-        let height: u64 = resp.block.header.height.parse().unwrap();
-        client.get_block(height).await.unwrap();
     }
 }

--- a/src/sequencer_block.rs
+++ b/src/sequencer_block.rs
@@ -193,21 +193,8 @@ pub fn cosmos_tx_body_to_sequencer_msgs(tx_body: TxBody) -> eyre::Result<Vec<Seq
 
 #[cfg(test)]
 mod test {
-    use super::{
-        cosmos_tx_body_to_sequencer_msgs, parse_cosmos_tx, SequencerBlock, SEQUENCER_TYPE_URL,
-    };
+    use super::{cosmos_tx_body_to_sequencer_msgs, parse_cosmos_tx, SEQUENCER_TYPE_URL};
     use crate::base64_string::Base64String;
-    use crate::sequencer::SequencerClient;
-
-    #[tokio::test]
-    async fn test_header_verify_hashes() {
-        let cosmos_endpoint = "http://localhost:1317".to_string();
-        let client = SequencerClient::new(cosmos_endpoint).unwrap();
-        let resp = client.get_latest_block().await.unwrap();
-        let sequencer_block = SequencerBlock::from_cosmos_block(resp.block).unwrap();
-        sequencer_block.verify_data_hash().unwrap();
-        sequencer_block.verify_block_hash().unwrap();
-    }
 
     #[test]
     fn test_parse_primary_tx() {

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -10,7 +10,7 @@ fn tx_to_prost_bytes(tx: Vec<u8>) -> prost::alloc::vec::Vec<u8> {
     buf
 }
 
-pub(crate) fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
+pub fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
     let txs = txs
         .iter()
         .map(|tx| tx_to_prost_bytes(tx.0.clone()))
@@ -19,22 +19,4 @@ pub(crate) fn txs_to_data_hash(txs: &[Base64String]) -> TmHash {
     TmHash::Sha256(merkle::simple_hash_from_byte_vectors::<
         tendermint::crypto::default::Sha256,
     >(&txs))
-}
-
-#[cfg(test)]
-mod test {
-    use super::txs_to_data_hash;
-    use crate::sequencer::SequencerClient;
-
-    #[tokio::test]
-    async fn test_txs_to_data_hash() {
-        let cosmos_endpoint = "http://localhost:1317".to_string();
-        let client = SequencerClient::new(cosmos_endpoint).unwrap();
-        let resp = client.get_latest_block().await.unwrap();
-        let data_hash = txs_to_data_hash(&resp.block.data.txs);
-        assert_eq!(
-            data_hash.as_bytes(),
-            &resp.block.header.data_hash.unwrap().0
-        );
-    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -128,7 +128,7 @@ impl Header {
     /// FIXME: This looks exactly like the `TryFrom<RawHeader>` definition that tendermint
     /// uses: https://docs.rs/tendermint/0.30.0/tendermint/block/header/struct.Header.html#impl-TryFrom%3CHeader%3E-for-Header
     /// We should use their impl instead of rolling our own.
-    fn to_tendermint_header(&self) -> eyre::Result<TmHeader> {
+    pub fn to_tendermint_header(&self) -> eyre::Result<TmHeader> {
         let last_block_id = self
             .last_block_id
             .as_ref()
@@ -186,20 +186,5 @@ impl Header {
             evidence_hash,
             proposer_address: AccountId::try_from(self.proposer_address.0.clone())?,
         })
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use crate::sequencer::SequencerClient;
-
-    #[tokio::test]
-    async fn test_header_to_tendermint_header() {
-        let cosmos_endpoint = "http://localhost:1317".to_string();
-        let client = SequencerClient::new(cosmos_endpoint).unwrap();
-        let resp = client.get_latest_block().await.unwrap();
-        let tm_header = &resp.block.header.to_tendermint_header().unwrap();
-        let tm_header_hash = tm_header.hash();
-        assert_eq!(tm_header_hash.as_bytes(), &resp.block_id.hash.0);
     }
 }

--- a/templates/sequencer_relayer_stack.yaml.jinja2
+++ b/templates/sequencer_relayer_stack.yaml.jinja2
@@ -1,0 +1,150 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: celestia-env
+  namespace: default
+data:
+  coins: "1000000000000000utia"
+  validator_stake: "5000000000utia"
+  chainid: "test"
+  keyring_backend: "test"
+  validator_key_name: "validator"
+  # evm address corresponds to private key:
+  # da6ed55cb2894ac2c9c10209c09de8e8b9d109b910338d5bf3d747a7e1fc9eb9
+  evm_address: "0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488"
+  home_dir: "/home/celestia"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metro-env
+  namespace: default
+data:
+  coins: "1000000000000000utick"
+  validator_stake: "5000000000utick"
+  chainid: "test"
+  keyring_backend: "test"
+  validator_key_name: "validator"
+  # evm address corresponds to private key:
+  # da6ed55cb2894ac2c9c10209c09de8e8b9d109b910338d5bf3d747a7e1fc9eb9
+  evm_address: "0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488"
+  home_dir: "/home/metro"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: "2023-04-03T10:34:40Z"
+  name: {{ pod_name }}
+spec:
+  # securityContext:
+  #   runAsUser: 10001
+  initContainers:
+    - command:
+      - /scripts/init-celestia-appd-podman.sh
+      name: init-celestia-app
+      image: "ghcr.io/astriaorg/celestia-app:v0.11.0"
+      volumeMounts:
+        - mountPath: /scripts/
+          name: scripts-volume
+        - mountPath: /home/celestia
+          name: {{ celestia_home_volume }}
+      envFrom:
+        - configMapRef:
+            name: celestia-env
+    - command:
+      - /scripts/init-bridge-podman.sh
+      name: init-bridge
+      image: "ghcr.io/astriaorg/celestia-node:test-sha-07fa3e7"
+      volumeMounts:
+        - mountPath: /scripts/
+          name: scripts-volume
+        - mountPath: /home/celestia
+          name: {{ celestia_home_volume }}
+      env:
+        - name: home_dir
+          valueFrom:
+            configMapKeyRef:
+              name: celestia-env
+              key: home_dir
+    - command:
+      - /scripts/init-metro-podman.sh
+      name: init-metro
+      image: "ghcr.io/astriaorg/metro:0.0.2"
+      volumeMounts:
+        - mountPath: /scripts/
+          name: scripts-volume
+        - mountPath: /home/metro
+          name: {{ metro_home_volume }}
+      envFrom:
+        - configMapRef:
+            name: metro-env
+    - command:
+      - /scripts/configure-metro-podman.sh
+      name: configure-metro
+      image: ghcr.io/tomwright/dasel:alpine
+      env:
+        - name: home_dir
+          valueFrom:
+            configMapKeyRef:
+              name: metro-env
+              key: home_dir
+      volumeMounts:
+        - mountPath: /scripts/
+          name: scripts-volume
+        - mountPath: /home/metro
+          name: {{ metro_home_volume }}
+  containers:
+    - name: celestia-app
+      command: ["/scripts/start-celestia-appd-podman.sh"]
+      image: "ghcr.io/astriaorg/celestia-app:v0.11.0"
+      envFrom:
+        - configMapRef:
+            name: celestia-env
+      volumeMounts:
+      - mountPath: /scripts/
+        name: scripts-volume
+      - mountPath: /home/celestia
+        name: {{ celestia_home_volume }}
+    - name: celestia-bridge
+      command:
+      - /scripts/start-bridge-podman.sh
+      image: "ghcr.io/astriaorg/celestia-node:test-sha-07fa3e7"
+      volumeMounts:
+        - mountPath: /scripts/
+          name: scripts-volume
+        - mountPath: /home/celestia
+          name: {{ celestia_home_volume }}
+      envFrom:
+        - configMapRef:
+            name: celestia-env
+      ports:
+        - containerPort: 26659
+          hostPort: {{ bridge_host_port }}
+    - name: metro-sequencer
+      command: ["/scripts/start-metro-podman.sh"]
+      image: "ghcr.io/astriaorg/metro:0.0.2"
+      ports:
+        - containerPort: 1318
+          hostPort: {{ sequencer_host_port }}
+      volumeMounts:
+        - mountPath: /scripts/
+          name: scripts-volume
+        - mountPath: /home/metro
+          name: {{ metro_home_volume }}
+      envFrom:
+        - configMapRef:
+            name: metro-env
+  hostname: test_sequencer_relayer
+  restartPolicy: OnFailure
+  volumes:
+  - hostPath:
+      path: {{ scripts_host_volume }}
+      readOnly: true
+      type: Directory
+    name: scripts-volume
+  - emptyDir: {}
+    name: {{ celestia_home_volume }}
+  - emptyDir: {}
+    name: {{ metro_home_volume }}
+    
+status: {}

--- a/tests/it/da.rs
+++ b/tests/it/da.rs
@@ -1,0 +1,142 @@
+use ed25519_dalek::{Keypair, PublicKey};
+use rand::rngs::OsRng;
+use std::{collections::HashMap, time::Duration};
+
+use sequencer_relayer::{
+    base64_string::Base64String,
+    da::CelestiaClient,
+    sequencer_block::{get_namespace, IndexedTransaction, SequencerBlock, DEFAULT_NAMESPACE},
+};
+
+use crate::helper::{init_environment, init_stack, wait_until_ready};
+
+#[tokio::test]
+async fn get_latest_height() {
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+
+    // FIXME: use a more reliable check to ensure that data
+    // is available on celestia/the data availability latyer.
+    // Right now we have to explicitly wait a sufficient period
+    // of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(40)).await;
+
+    let base_url = info.make_bridge_endpoint();
+    let client = CelestiaClient::new(base_url).unwrap();
+
+    let height = client.get_latest_height().await.unwrap();
+    assert!(height > 0);
+}
+
+#[tokio::test]
+async fn get_blocks_public_key_filter() {
+    // test that get_blocks only gets blocked signed with a specific key
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+
+    // FIXME: use a more reliable check to ensure that data
+    // is available on celestia/the data availability latyer.
+    // Right now we have to explicitly wait a sufficient period
+    // of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(40)).await;
+
+    let base_url = info.make_bridge_endpoint();
+    let client = CelestiaClient::new(base_url).unwrap();
+
+    let tx = Base64String(b"noot_was_here".to_vec());
+
+    let block_hash = Base64String(vec![99; 32]);
+    let block = SequencerBlock {
+        block_hash: block_hash.clone(),
+        header: Default::default(),
+        sequencer_txs: vec![IndexedTransaction {
+            index: 0,
+            transaction: tx.clone(),
+        }],
+        rollup_txs: HashMap::new(),
+    };
+
+    println!("submitting block");
+    let keypair = Keypair::generate(&mut OsRng);
+    let submit_block_resp = client.submit_block(block, &keypair).await.unwrap();
+    let height = submit_block_resp
+        .namespace_to_block_num
+        .get(&DEFAULT_NAMESPACE.to_string())
+        .unwrap();
+
+    // generate new, different key
+    let keypair = Keypair::generate(&mut OsRng);
+    let public_key = PublicKey::from_bytes(&keypair.public.to_bytes()).unwrap();
+    println!("getting blocks");
+    let resp = client.get_blocks(*height, Some(&public_key)).await.unwrap();
+    assert!(resp.is_empty());
+}
+
+#[tokio::test]
+async fn celestia_client() {
+    // test submit_block
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+
+    // FIXME: use a more reliable check to ensure that data
+    // is available on celestia/the data availability latyer.
+    // Right now we have to explicitly wait a sufficient period
+    // of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(40)).await;
+
+    let base_url = info.make_bridge_endpoint();
+    let client = CelestiaClient::new(base_url).unwrap();
+
+    let tx = Base64String(b"noot_was_here".to_vec());
+    let secondary_namespace = get_namespace(b"test_namespace");
+    let secondary_tx = Base64String(b"noot_was_here_too".to_vec());
+
+    let block_hash = Base64String(vec![99; 32]);
+    let mut block = SequencerBlock {
+        block_hash: block_hash.clone(),
+        header: Default::default(),
+        sequencer_txs: vec![IndexedTransaction {
+            index: 0,
+            transaction: tx.clone(),
+        }],
+        rollup_txs: HashMap::new(),
+    };
+    block.rollup_txs.insert(
+        secondary_namespace.clone(),
+        vec![IndexedTransaction {
+            index: 1,
+            transaction: secondary_tx.clone(),
+        }],
+    );
+
+    let keypair = Keypair::generate(&mut OsRng);
+    let public_key = PublicKey::from_bytes(&keypair.public.to_bytes()).unwrap();
+
+    let submit_block_resp = client.submit_block(block, &keypair).await.unwrap();
+    let height = submit_block_resp
+        .namespace_to_block_num
+        .get(&DEFAULT_NAMESPACE.to_string())
+        .unwrap();
+
+    // test check_block_availability
+    let resp = client.check_block_availability(*height).await.unwrap();
+    assert_eq!(resp.height, *height);
+
+    // test get_blocks
+    let resp = client.get_blocks(*height, Some(&public_key)).await.unwrap();
+    assert_eq!(resp.len(), 1);
+    assert_eq!(resp[0].block_hash, block_hash);
+    assert_eq!(resp[0].header, Default::default());
+    assert_eq!(resp[0].sequencer_txs.len(), 1);
+    assert_eq!(resp[0].sequencer_txs[0].index, 0);
+    assert_eq!(resp[0].sequencer_txs[0].transaction, tx);
+    assert_eq!(resp[0].rollup_txs.len(), 1);
+    assert_eq!(resp[0].rollup_txs[&secondary_namespace][0].index, 1);
+    assert_eq!(
+        resp[0].rollup_txs[&secondary_namespace][0].transaction,
+        secondary_tx
+    );
+}

--- a/tests/it/helper.rs
+++ b/tests/it/helper.rs
@@ -1,0 +1,143 @@
+use std::{
+    sync::atomic::{AtomicU16, Ordering},
+    time::Duration,
+};
+
+use askama::Template;
+use once_cell::sync::Lazy;
+use podman_api::{Id, Podman};
+use tokio::sync::mpsc::UnboundedSender;
+use uuid::Uuid;
+
+static HOST_PORT: AtomicU16 = AtomicU16::new(1024);
+
+static STOP_POD_TX: Lazy<UnboundedSender<String>> = Lazy::new(|| {
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _ = std::thread::spawn(move || {
+        let podman = init_environment();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()
+            .unwrap();
+        rt.block_on(async move {
+            while let Some(pod_name) = rx.recv().await {
+                let podman = podman.clone();
+                // spawn "fire and forget" tasks so the force removes are sent
+                // to podman immediately and without waiting for a server response.
+                tokio::spawn(async move {
+                    if let Err(e) = podman.pods().get(&pod_name).remove().await {
+                        eprintln!("received error while removing pod `{pod_name}`: {e:?}");
+                    }
+                });
+            }
+        });
+    });
+    tx
+});
+
+#[derive(Template)]
+#[template(path = "sequencer_relayer_stack.yaml.jinja2")]
+struct SequencerRelayerStack<'a> {
+    pod_name: &'a str,
+    celestia_home_volume: &'a str,
+    metro_home_volume: &'a str,
+    scripts_host_volume: &'a str,
+    bridge_host_port: u16,
+    sequencer_host_port: u16,
+}
+
+pub fn init_environment() -> Podman {
+    #[cfg(target_os = "linux")]
+    let podman_dir = {
+        let uid = users::get_effective_uid();
+        std::path::PathBuf::from(format!("/run/user/{uid}/podman"))
+    };
+    #[cfg(target_os = "macos")]
+    let podman_dir = {
+        let home_dir = home::home_dir().expect("there should always be a homedir on macos");
+        home_dir.join(".local/share/containers/podman/machine/qemu")
+    };
+    if podman_dir.exists() {
+        Podman::unix(podman_dir.join("podman.sock"))
+    } else {
+        panic!("podman socket not found at `{}`", podman_dir.display(),);
+    }
+}
+
+pub struct StackInfo {
+    pub pod_name: String,
+    pub bridge_host_port: u16,
+    pub sequencer_host_port: u16,
+    tx: UnboundedSender<String>,
+}
+
+impl StackInfo {
+    pub fn make_bridge_endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}", self.bridge_host_port,)
+    }
+
+    pub fn make_sequencer_endpoint(&self) -> String {
+        format!("http://127.0.0.1:{}", self.sequencer_host_port,)
+    }
+}
+
+impl Drop for StackInfo {
+    fn drop(&mut self) {
+        if let Err(e) = self.tx.send(self.pod_name.clone()) {
+            eprintln!(
+                "failed sending pod `{name}` to cleanup task while dropping StackInfo: {e:?}",
+                name = self.pod_name,
+            )
+        }
+    }
+}
+
+pub async fn init_stack(podman: &Podman) -> StackInfo {
+    let id = Uuid::new_v4().simple();
+    let pod_name = format!("sequencer_relayer_stack-{id}");
+    let celestia_home_volume = format!("celestia-home-volume-{id}");
+    let metro_home_volume = format!("metro-home-volume-{id}");
+    let bridge_host_port = HOST_PORT.fetch_add(1, Ordering::Relaxed);
+    let sequencer_host_port = HOST_PORT.fetch_add(1, Ordering::Relaxed);
+
+    let scripts_host_volume = format!("{}/containers/", env!("CARGO_MANIFEST_DIR"));
+
+    let stack = SequencerRelayerStack {
+        pod_name: &pod_name,
+        celestia_home_volume: &celestia_home_volume,
+        metro_home_volume: &metro_home_volume,
+        scripts_host_volume: &scripts_host_volume,
+        bridge_host_port,
+        sequencer_host_port,
+    };
+
+    let pod_kube_yaml = stack.render().unwrap();
+
+    let stack_info = StackInfo {
+        pod_name,
+        bridge_host_port,
+        sequencer_host_port,
+        tx: Lazy::force(&STOP_POD_TX).clone(),
+    };
+
+    if let Err(e) = podman
+        .play_kubernetes_yaml(&Default::default(), pod_kube_yaml)
+        .await
+    {
+        eprintln!("failed playing YAML failed on podman: {e:?}");
+        panic!("{e:?}");
+    }
+
+    stack_info
+}
+
+pub async fn wait_until_ready(podman: &Podman, id: impl Into<Id>) {
+    let pod = podman.pods().get(id);
+    loop {
+        let resp = pod.inspect().await.unwrap();
+        if resp.state.as_deref() == Some("Running") {
+            break;
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,0 +1,6 @@
+mod da;
+mod helper;
+mod sequencer;
+mod sequencer_block;
+mod transaction;
+mod types;

--- a/tests/it/sequencer.rs
+++ b/tests/it/sequencer.rs
@@ -1,0 +1,38 @@
+use std::time::Duration;
+
+use crate::helper::{init_environment, init_stack, wait_until_ready};
+use sequencer_relayer::sequencer::SequencerClient;
+
+#[tokio::test]
+async fn get_latest_block() {
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+    let cosmos_endpoint = info.make_sequencer_endpoint();
+
+    // FIXME: use a more reliable check to ensure any blocks are
+    // available on the sequencer. Right now we have to explicitly
+    // wait a sufficient period of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    let client = SequencerClient::new(cosmos_endpoint).unwrap();
+    client.get_latest_block().await.unwrap();
+}
+
+#[tokio::test]
+async fn get_block() {
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+    let cosmos_endpoint = info.make_sequencer_endpoint();
+
+    // FIXME: use a more reliable check to ensure any blocks are
+    // available on the sequencer. Right now we have to explicitly
+    // wait a sufficient period of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    let client = SequencerClient::new(cosmos_endpoint).unwrap();
+    let resp = client.get_latest_block().await.unwrap();
+    let height: u64 = resp.block.header.height.parse().unwrap();
+    client.get_block(height).await.unwrap();
+}

--- a/tests/it/sequencer_block.rs
+++ b/tests/it/sequencer_block.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use crate::helper::{init_environment, init_stack, wait_until_ready};
+
+use sequencer_relayer::{sequencer::SequencerClient, sequencer_block::SequencerBlock};
+
+#[tokio::test]
+async fn header_verify_hashes() {
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+    let cosmos_endpoint = info.make_sequencer_endpoint();
+
+    // FIXME: use a more reliable check to ensure any blocks are
+    // available on the sequencer. Right now we have to explicitly
+    // wait a sufficient period of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(30)).await;
+
+    let client = SequencerClient::new(cosmos_endpoint).unwrap();
+    let resp = client.get_latest_block().await.unwrap();
+    let sequencer_block = SequencerBlock::from_cosmos_block(resp.block).unwrap();
+    sequencer_block.verify_data_hash().unwrap();
+    sequencer_block.verify_block_hash().unwrap();
+}

--- a/tests/it/transaction.rs
+++ b/tests/it/transaction.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use sequencer_relayer::{sequencer::SequencerClient, transaction};
+
+use crate::helper::{init_environment, init_stack, wait_until_ready};
+
+#[tokio::test]
+async fn txs_to_data_hash() {
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+    let cosmos_endpoint = info.make_sequencer_endpoint();
+
+    // FIXME: use a more reliable check to ensure any blocks are
+    // available on the sequencer. Right now we have to explicitly
+    // wait a sufficient period of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(20)).await;
+
+    let client = SequencerClient::new(cosmos_endpoint).unwrap();
+    let resp = client.get_latest_block().await.unwrap();
+    let data_hash = transaction::txs_to_data_hash(&resp.block.data.txs);
+    assert_eq!(
+        data_hash.as_bytes(),
+        &resp.block.header.data_hash.unwrap().0
+    );
+}

--- a/tests/it/types.rs
+++ b/tests/it/types.rs
@@ -1,0 +1,24 @@
+use std::time::Duration;
+
+use sequencer_relayer::sequencer::SequencerClient;
+
+use crate::helper::{init_environment, init_stack, wait_until_ready};
+
+#[tokio::test]
+async fn test_header_to_tendermint_header() {
+    let podman = init_environment();
+    let info = init_stack(&podman).await;
+    wait_until_ready(&podman, &info.pod_name).await;
+    let cosmos_endpoint = info.make_sequencer_endpoint();
+
+    // FIXME: use a more reliable check to ensure any blocks are
+    // available on the sequencer. Right now we have to explicitly
+    // wait a sufficient period of time. This is flaky.
+    tokio::time::sleep(Duration::from_secs(20)).await;
+
+    let client = SequencerClient::new(cosmos_endpoint).unwrap();
+    let resp = client.get_latest_block().await.unwrap();
+    let tm_header = &resp.block.header.to_tendermint_header().unwrap();
+    let tm_header_hash = tm_header.hash();
+    assert_eq!(tm_header_hash.as_bytes(), &resp.block_id.hash.0);
+}


### PR DESCRIPTION
This PR changes CI tests to use podman instead of docker-compose. The idea behind this is to have clean per-test environments so that tests can run concurrently without having to worry about contamination.

In terms of CI the biggest change is that we have to add the opensuse kubic repository because the provide podman builds for ubuntu-22.04. Github only provides podman 3.4.4, while the current version is 4.4.4. Background reading: https://podman.io/getting-started/installation#ubuntu

# The good

Fully independent integration tests that run concurrently. No more (potential) flakiness because one forgot to run tests on one thread. Theoretically this should also be a lot faster (at the expense of higher RAM usage).

The tests create and destroy the pods automatically by:
+ assigning unique names to each pod & its emptyDir ephemeral volumes (this is to work around some podman quirks), and by using AtomicU16 to bind the sequencer/metro and bridge to unique ports for each test (in the range 1024-65536)
+ using a custom drop impl + a dedicated tokio runtime on an extra thread to automatically destroy each test-pod after the test completed (even if the test panicked and didn't end properly)

# The soso
+ podman does not allow to use 0 as a hostPort to just assign the next best one. This kind of makes sense when deploying pods, but still makes me sense. Hence the AtomciU16 workaround mentioned above. One must also ensure that the ports in that range are not taken (in practice this means that 1024 to ca. 1060 must be empty). Also this limits the number of tests we can run to 30k (2 ports per test); not too much of an issue I figure, lol

# The ugly
+ there is no easy way to ensure that blocks are indeed available when hitting either sequencer or the data availability layer (=celestia). On the one hand the tests wait for the pod status to change to Running. But on the other that doesn't mean a lot. So in practice we just wait another 20 seconds for tests hitting the sequencer, and 40 seconds for hitting the data availability endpoints (I found that that takes longer)
+ the github actions take a long time, for one because the rust builds are slow, but on top of it we also have to wait for the environment to be truly settled and ready.

# Open questions (important before merging!)
This PR relies on a celestia-node image that I have published to my private github here (and made public): ghcr.io/superfluffy/sequencer-relayer:celestia-node-test-v0.6.1. Its dockerfile can be found at `docker/Dockerfile.celestia-node` and bascially just installs curl and jq.
```dockerfile
FROM ghcr.io/celestiaorg/celestia-node:0.6.1

RUN apt-get update && apt-get -y install jq curl

ENTRYPOINT ["/bin/bash"]
```

This is not very nice, but was necessary to make things work. What is our strategy for building and deploying such images? Should they live under `sequencer-relayer`? Or a fork of `celestia-node`?