### PR TITLE
feat: implement api server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,10 +117,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "axum"
+version = "0.6.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "113713495a32dd0ab52baf5c10044725aa3aec00b31beda84218e469029b72a3"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags",
+ "bytes 1.4.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes 1.4.0",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "base64"
@@ -1058,6 +1118,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1690,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1728,7 @@ name = "sequencer-relayer"
 version = "0.1.0"
 dependencies = [
  "askama",
+ "axum",
  "base64 0.21.0",
  "bech32",
  "clap",
@@ -1664,6 +1737,7 @@ dependencies = [
  "eyre",
  "hex",
  "home",
+ "http",
  "once_cell",
  "podman-api",
  "prost",
@@ -1720,6 +1794,15 @@ checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+dependencies = [
  "serde",
 ]
 
@@ -1864,6 +1947,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "tar"
@@ -2082,6 +2171,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project 1.0.12",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c20c8dbed6283a09604c3e69b4b7eeb54e298b8a600d4d5ecb5ad39de609f1d0"
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ tokio = { version = "1.24", features = [ "macros", "rt-multi-thread" ] }
 tracing = "0.1"
 tracing-subscriber = "0.2.15"
 clap = { version = "4.1.9", features = ["derive"] }
+axum = "0.6.16"
+http = "0.2.9"
 
 [dependencies.rs-cnc]
 git = "https://github.com/astriaorg/rs-cnc.git"

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,102 @@
+use std::net::SocketAddr;
+
+use axum::{
+    extract::State,
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use http::status::StatusCode;
+use serde::Serialize;
+use tokio::sync::watch::Receiver;
+
+use crate::relayer::State as RelayerState;
+
+pub async fn start(addr: SocketAddr, relayer_state: Receiver<RelayerState>) {
+    let app = Router::new()
+        .route("/healthz", get(get_healthz))
+        .route("/readyz", get(get_readyz))
+        .route("/status", get(get_status))
+        .with_state(relayer_state);
+
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .expect("app server exited unexpectedly");
+}
+
+async fn get_healthz(State(relayer_status): State<Receiver<RelayerState>>) -> Healthz {
+    match relayer_status.borrow().is_ready() {
+        true => Healthz::Ok,
+        false => Healthz::Degraded,
+    }
+}
+
+async fn get_readyz(State(relayer_status): State<Receiver<RelayerState>>) -> Readyz {
+    match relayer_status.borrow().is_ready() {
+        true => Readyz::Ok,
+        false => Readyz::NotReady,
+    }
+}
+
+async fn get_status(State(relayer_status): State<Receiver<RelayerState>>) -> Json<Status> {
+    let status = Status::from_relayer_status(&relayer_status.borrow());
+    Json(status)
+}
+
+enum Healthz {
+    Ok,
+    Degraded,
+}
+
+impl IntoResponse for Healthz {
+    fn into_response(self) -> Response {
+        #[derive(Debug, Serialize)]
+        struct ReadyzBody {
+            status: &'static str,
+        }
+        let (status, msg) = match self {
+            Self::Ok => (StatusCode::OK, "ok"),
+            Self::Degraded => (StatusCode::GATEWAY_TIMEOUT, "degraded"),
+        };
+        let mut response = Json(ReadyzBody { status: msg }).into_response();
+        *response.status_mut() = status;
+        response
+    }
+}
+
+enum Readyz {
+    Ok,
+    NotReady,
+}
+
+impl IntoResponse for Readyz {
+    fn into_response(self) -> Response {
+        #[derive(Debug, Serialize)]
+        struct ReadyzBody {
+            status: &'static str,
+        }
+        let (status, msg) = match self {
+            Self::Ok => (StatusCode::OK, "ok"),
+            Self::NotReady => (StatusCode::SERVICE_UNAVAILABLE, "not ready"),
+        };
+        let mut response = Json(ReadyzBody { status: msg }).into_response();
+        *response.status_mut() = status;
+        response
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct Status {
+    current_sequencer_height: Option<u64>,
+    current_data_availability_height: Option<u64>,
+}
+
+impl Status {
+    fn from_relayer_status(relayer_status: &RelayerState) -> Self {
+        Self {
+            current_sequencer_height: relayer_status.current_sequencer_height,
+            current_data_availability_height: relayer_status.current_data_availability_height,
+        }
+    }
+}

--- a/src/bin/relayer.rs
+++ b/src/bin/relayer.rs
@@ -1,18 +1,15 @@
-use bech32::{self, ToBase32, Variant};
 use clap::Parser;
 use dirs::home_dir;
-use serde::Deserialize;
-use tracing::{info, warn};
+use tracing::info;
 use tracing_subscriber::EnvFilter;
 
-use std::{str::FromStr, time};
+use std::{net::SocketAddr, time};
 
 use sequencer_relayer::{
-    base64_string::Base64String,
+    api,
     da::CelestiaClient,
-    keys::{private_key_bytes_to_keypair, validator_hex_to_address},
+    relayer::{Relayer, ValidatorPrivateKeyFile},
     sequencer::SequencerClient,
-    sequencer_block::SequencerBlock,
 };
 
 pub const DEFAULT_SEQUENCER_ENDPOINT: &str = "http://localhost:1317";
@@ -39,23 +36,13 @@ struct Args {
     #[arg(short, long, default_value = ".metro/config/priv_validator_key.json")]
     validator_key_file: String,
 
+    /// RPC port to listen on. Default: 2450
+    #[arg(short, long, default_value = "2450")]
+    rpc_port: u16,
+
     /// Log level. One of debug, info, warn, or error
     #[arg(short, long, default_value = "info")]
     log: String,
-}
-
-#[derive(Deserialize)]
-pub struct ValidatorPrivateKeyFile {
-    pub address: String,
-    pub pub_key: KeyWithType,
-    pub priv_key: KeyWithType,
-}
-
-#[derive(Deserialize)]
-pub struct KeyWithType {
-    #[serde(rename = "type")]
-    pub key_type: String,
-    pub value: String,
 }
 
 #[tokio::main]
@@ -78,22 +65,6 @@ async fn main() {
     let key_file: ValidatorPrivateKeyFile =
         serde_json::from_str(&key_file).expect("failed to unmarshal validator key file");
 
-    // generate our private-public keypair
-    let keypair = private_key_bytes_to_keypair(
-        &Base64String::from_string(key_file.priv_key.value)
-            .expect("failed to decode validator private key; must be base64 string")
-            .0,
-    )
-    .expect("failed to convert validator private key to keypair");
-
-    // generate our bech32 validator address
-    let address = validator_hex_to_address(&key_file.address)
-        .expect("failed to convert validator address to bech32");
-
-    // generate our validator address bytes
-    let address_bytes = hex::decode(&key_file.address)
-        .expect("failed to decode validator address; must be hex string");
-
     let sequencer_client =
         SequencerClient::new(args.sequencer_endpoint).expect("failed to create sequencer client");
     let da_client = CelestiaClient::new(args.celestia_endpoint)
@@ -101,65 +72,17 @@ async fn main() {
 
     let sleep_duration = time::Duration::from_millis(args.block_time);
     let mut interval = tokio::time::interval(sleep_duration);
-    let mut highest_block_number = 0u64;
+
+    let relayer = Relayer::new(sequencer_client, da_client, key_file);
+    let relayer_state = relayer.subscribe_to_state();
+
+    let _api_server_task = tokio::task::spawn(async move {
+        let api_addr = SocketAddr::from(([127, 0, 0, 1], args.rpc_port));
+        api::start(api_addr, relayer_state).await;
+    });
 
     loop {
         interval.tick().await;
-        match sequencer_client.get_latest_block().await {
-            Ok(resp) => {
-                let maybe_height: Result<u64, <u64 as FromStr>::Err> =
-                    resp.block.header.height.parse();
-                if let Err(e) = maybe_height {
-                    warn!(
-                        error = ?e,
-                        "got invalid block height {} from sequencer",
-                        resp.block.header.height,
-                    );
-                    continue;
-                }
-
-                let height = maybe_height.unwrap();
-                if height <= highest_block_number {
-                    continue;
-                }
-
-                info!("got block with height {} from sequencer", height);
-                highest_block_number = height;
-
-                if resp.block.header.proposer_address.0 != address_bytes {
-                    let proposer_address = bech32::encode(
-                        "metrovalcons",
-                        resp.block.header.proposer_address.0.to_base32(),
-                        Variant::Bech32,
-                    )
-                    .expect("should encode block proposer address");
-                    info!(
-                        %proposer_address,
-                        validator_address = %address,
-                        "ignoring block: proposer address is not ours",
-                    );
-                    continue;
-                }
-
-                let sequencer_block = match SequencerBlock::from_cosmos_block(resp.block) {
-                    Ok(block) => block,
-                    Err(e) => {
-                        warn!(error = ?e, "failed to convert block to DA block");
-                        continue;
-                    }
-                };
-
-                let tx_count =
-                    sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
-                match da_client.submit_block(sequencer_block, &keypair).await {
-                    Ok(resp) => info!(
-                        "submitted sequencer block {} to DA layer (included in block {}): tx count={}",
-                        height, resp.height, &tx_count,
-                    ),
-                    Err(e) => warn!(error = ?e, "failed to submit block to DA layer"),
-                }
-            }
-            Err(e) => warn!(error = ?e, "failed to get latest block from sequencer"),
-        }
+        relayer.run().await;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod api;
 pub mod base64_string;
 pub mod da;
 pub mod keys;
+pub mod relayer;
 pub mod sequencer;
 pub mod sequencer_block;
 pub mod transaction;

--- a/src/relayer.rs
+++ b/src/relayer.rs
@@ -1,0 +1,163 @@
+use bech32::{self, ToBase32, Variant};
+use serde::Deserialize;
+use std::str::FromStr;
+use tokio::sync::watch;
+use tracing::{info, warn};
+
+use crate::base64_string::Base64String;
+use crate::da::CelestiaClient;
+use crate::keys::{private_key_bytes_to_keypair, validator_hex_to_address};
+use crate::sequencer::SequencerClient;
+use crate::sequencer_block::SequencerBlock;
+
+#[derive(Deserialize)]
+pub struct ValidatorPrivateKeyFile {
+    pub address: String,
+    pub pub_key: KeyWithType,
+    pub priv_key: KeyWithType,
+}
+
+#[derive(Deserialize)]
+pub struct KeyWithType {
+    #[serde(rename = "type")]
+    pub key_type: String,
+    pub value: String,
+}
+
+pub struct Relayer {
+    sequencer_client: SequencerClient,
+    da_client: CelestiaClient,
+    keypair: ed25519_dalek::Keypair,
+    validator_address: String,
+    validator_address_bytes: Vec<u8>,
+
+    state: watch::Sender<State>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct State {
+    pub(crate) current_sequencer_height: Option<u64>,
+    pub(crate) current_data_availability_height: Option<u64>,
+}
+
+impl State {
+    pub fn is_ready(&self) -> bool {
+        self.current_sequencer_height.is_some() && self.current_data_availability_height.is_some()
+    }
+}
+
+impl Relayer {
+    pub fn new(
+        sequencer_client: SequencerClient,
+        da_client: CelestiaClient,
+        key_file: ValidatorPrivateKeyFile,
+    ) -> Self {
+        // generate our private-public keypair
+        let keypair = private_key_bytes_to_keypair(
+            &Base64String::from_string(key_file.priv_key.value)
+                .expect("failed to decode validator private key; must be base64 string")
+                .0,
+        )
+        .expect("failed to convert validator private key to keypair");
+
+        // generate our bech32 validator address
+        let validator_address = validator_hex_to_address(&key_file.address)
+            .expect("failed to convert validator address to bech32");
+
+        // generate our validator address bytes
+        let validator_address_bytes = hex::decode(&key_file.address)
+            .expect("failed to decode validator address; must be hex string");
+
+        let (state, _) = watch::channel(State::default());
+
+        Self {
+            sequencer_client,
+            da_client,
+            keypair,
+            validator_address,
+            validator_address_bytes,
+            state,
+        }
+    }
+
+    pub fn subscribe_to_state(&self) -> watch::Receiver<State> {
+        self.state.subscribe()
+    }
+
+    async fn get_latest_block(&self) -> eyre::Result<State> {
+        let mut new_state = (*self.state.borrow()).clone();
+        let resp = self.sequencer_client.get_latest_block().await?;
+
+        let maybe_height: Result<u64, <u64 as FromStr>::Err> = resp.block.header.height.parse();
+        if let Err(e) = maybe_height {
+            warn!(
+                error = ?e,
+                "got invalid block height {} from sequencer",
+                resp.block.header.height,
+            );
+            return Ok(new_state);
+        }
+
+        let height = maybe_height.unwrap();
+        if height <= *new_state.current_sequencer_height.get_or_insert(height) {
+            return Ok(new_state);
+        }
+
+        info!("got block with height {} from sequencer", height);
+        new_state.current_sequencer_height.replace(height);
+
+        if resp.block.header.proposer_address.0 != self.validator_address_bytes {
+            let proposer_address = bech32::encode(
+                "metrovalcons",
+                resp.block.header.proposer_address.0.to_base32(),
+                Variant::Bech32,
+            )
+            .expect("should encode block proposer address");
+            info!(
+                %proposer_address,
+                validator_address = %self.validator_address,
+                "ignoring block: proposer address is not ours",
+            );
+            return Ok(new_state);
+        }
+
+        let sequencer_block = match SequencerBlock::from_cosmos_block(resp.block) {
+            Ok(block) => block,
+            Err(e) => {
+                warn!(error = ?e, "failed to convert block to DA block");
+                return Ok(new_state);
+            }
+        };
+
+        let tx_count = sequencer_block.rollup_txs.len() + sequencer_block.sequencer_txs.len();
+        match self
+            .da_client
+            .submit_block(sequencer_block, &self.keypair)
+            .await
+        {
+            Ok(resp) => {
+                new_state
+                    .current_data_availability_height
+                    .replace(resp.height);
+                info!(
+                    sequencer_block = height,
+                    da_layer_block = resp.height,
+                    tx_count,
+                    "submitted sequencer block to DA layer",
+                );
+            }
+            Err(e) => warn!(error = ?e, "failed to submit block to DA layer"),
+        }
+        Ok(new_state)
+    }
+
+    pub async fn run(&self) {
+        match self.get_latest_block().await {
+            Err(e) => warn!(error = ?e, "failed to get latest block from sequencer"),
+            Ok(new_state) if new_state != *self.state.borrow() => {
+                _ = self.state.send_replace(new_state);
+            }
+            Ok(_) => {}
+        }
+    }
+}


### PR DESCRIPTION
This is a rewrite of #29 to use `tokio::sync::watch` to allow less tight coupling between the execution of the relayer and the API service.

## Open tasks:

+ [ ] integration tests for the endpoints
+ [ ] instrumentation