### PR TITLE
use a fixed git rev for rs-cnc and fix compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
 [[package]]
 name = "rs-cnc"
 version = "0.1.0"
-source = "git+https://github.com/astriaorg/rs-cnc.git#2ebf140778db12835eba686f6c5111eb429218e1"
+source = "git+https://github.com/astriaorg/rs-cnc.git?rev=07d00be#07d00be1414c90064fe156da454415a9dc3d1c84"
 dependencies = [
  "base64 0.21.0",
  "bytes",

--- a/sequencer-relayer/Cargo.toml
+++ b/sequencer-relayer/Cargo.toml
@@ -30,6 +30,7 @@ sequencer-relayer-proto = { path = "../sequencer-relayer-proto" }
 
 [dependencies.rs-cnc]
 git = "https://github.com/astriaorg/rs-cnc.git"
+rev = "07d00be"
 default-features = false
 features = ["rustls"]
 

--- a/sequencer-relayer/src/da.rs
+++ b/sequencer-relayer/src/da.rs
@@ -130,6 +130,7 @@ impl CelestiaClient {
     pub fn new(endpoint: String) -> eyre::Result<Self> {
         let cnc = CelestiaNodeClient::builder()
             .base_url(endpoint)
+            .wrap_err("failed setting base URL for celestia node client; bad URL?")?
             .build()
             .wrap_err("failed creating celestia node client")?;
         Ok(CelestiaClient { client: cnc })


### PR DESCRIPTION
Because `rs-cnc` is a git dependency but does not use a fixed revision hash, it is prone to randomly break the moment a a breaking change is merged to its default branch.

This PR fixes the resulting miscompilation and uses a fixed revision to avoid this in the future.